### PR TITLE
Fix a rare bug when submitting a Bakerloo station

### DIFF
--- a/Assets/londonUndergroundScript.cs
+++ b/Assets/londonUndergroundScript.cs
@@ -842,7 +842,6 @@ public class londonUndergroundScript : MonoBehaviour
                     levelsPassed++;
                     Debug.LogFormat("[The London Underground #{0}] Correct! You took the {1} line to {2}. Journey complete.", moduleId, line1Line.text, line1Station.text);
                     LevelChecker();
-                    Start();
                 }
                 else if (line2Station.text != " ")
                 {
@@ -1656,7 +1655,7 @@ public class londonUndergroundScript : MonoBehaviour
 
 	private IEnumerator ProcessTwitchCommand(string command)
 	{
-		command = command.Replace("’", "'");
+		command = command.Replace("Â’", "'");
 		var commands = command.ToLowerInvariant().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 		if (commands.Length < 3 && commands[0] != "submit")
 			yield break;


### PR DESCRIPTION
If your departure and destination stations are both on the Bakerloo line, submitting a correct answer using Bakerloo would call the Start method twice, causing two stages to be processed at the same time.
As such, the extraneous Start() call has been removed.